### PR TITLE
add ephemeral-storage for kubernetes

### DIFF
--- a/good-code/orchestrator-simple/service.yaml
+++ b/good-code/orchestrator-simple/service.yaml
@@ -43,13 +43,14 @@ spec:
             - name: workspace-volume
               mountPath: /workspace
           resources:
-            # Bounty $25 Use ephemeral-storage to add space limits here
             requests:
               cpu: "1"
               memory: "1Gi"
+              ephemeral-storage: "1Gi"
             limits:
               cpu: "1"
               memory: "1Gi"
+              ephemeral-storage: "2Gi"
 
 ---
 apiVersion: v1


### PR DESCRIPTION
This Pr adds, [ephemeral-storage](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#setting-requests-and-limits-for-local-ephemeral-storage) for the container.
