### PR TITLE
fix: add ephemeral-storage to k8s

### DIFF
--- a/good-code/orchestrator-simple/service.yaml
+++ b/good-code/orchestrator-simple/service.yaml
@@ -50,6 +50,7 @@ spec:
             limits:
               cpu: "1"
               memory: "1Gi"
+              ephemeral-storage: "5Gi"
 
 ---
 apiVersion: v1


### PR DESCRIPTION
This pr adds:
- ephemeral-storage which persists storage only until the lifetime of a pod